### PR TITLE
Move to gradle 4.5

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.5-all.zip


### PR DESCRIPTION
Latest elasticsearch requires at least gradle 4.3, see :
* https://github.com/elastic/elasticsearch/blob/master/gradle/wrapper/gradle-wrapper.properties
* https://github.com/elastic/elasticsearch/pull/27885/files